### PR TITLE
Optimize runtime for PNG and JPEG

### DIFF
--- a/scripts/optimize-images.rb
+++ b/scripts/optimize-images.rb
@@ -41,6 +41,8 @@ image_optim = ImageOptim.new(
     :pngcrush => false, # redundant with oxipng
     :pngout => false, # redundant with oxipng
     :optipng => false, # redundant with oxipng
+    :jpegoptim => false, # redundant with jpegrecompress
+    :jpegtran => false, # redundant with jpegrecompress
     :svgo => {
         :enable_plugins => [
             # All lossless according to ImageOptim:

--- a/scripts/optimize-images.rb
+++ b/scripts/optimize-images.rb
@@ -37,10 +37,10 @@ end
 # Setup ImageOptim options.
 image_optim = ImageOptim.new(
     :nice => 0,
-    :advpng => {
-        :level => 3
-    },
-    :pngout => false,
+    :advpng => false, # redundant with oxipng
+    :pngcrush => false, # redundant with oxipng
+    :pngout => false, # redundant with oxipng
+    :optipng => false, # redundant with oxipng
     :svgo => {
         :enable_plugins => [
             # All lossless according to ImageOptim:


### PR DESCRIPTION
Disable optimizers that are unlikely to be useful. Prefers oxipng (recently introduced in image_optim) for PNG, and jpeg-recompress for JPEG.